### PR TITLE
Implement API Routes for Care Plans

### DIFF
--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -326,6 +326,28 @@ def get_user_care_plans(user_id):
 
     finally:
         db.close()
+
+
+@plant_care_bp.route("/care-plans/active", methods=["GET"])
+@jwt_required()
+@require_user_id
+def get_user_active_care_plans(user_id):
+    """Returns a list of all a user's active care plans."""
+    db = SessionLocal()
+    plant_care_service = PlantCareService(db)
+
+    try:
+        care_plans = plant_care_service.get_active_care_plans_for_user(user_id)
+        if not care_plans:
+            return jsonify({"error": "Unable to find any care plans."}), 404
+
+        return jsonify([serialize_care_plan(plan) for plan in care_plans]), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+    finally:
+        db.close()
 @plant_care_bp.route("/<int:care_log_id>", methods=["PATCH"])
 @jwt_required()
 @require_user_id

--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -348,6 +348,33 @@ def get_user_active_care_plans(user_id):
 
     finally:
         db.close()
+
+
+@plant_care_bp.route("/care-plans/<int:care_plan_id>", methods=["GET"])
+@jwt_required()
+@require_user_id
+def get_care_plan_by_id(user_id, care_plan_id):
+    """Returns a care plan if it exists and belong to the user."""
+    db = SessionLocal()
+    plant_care_service = PlantCareService(db)
+
+    try:
+        care_plan = plant_care_service.get_care_plan_by_id(care_plan_id)
+        if not care_plan:
+            return jsonify({"error": "Unable to find care plan."}), 404
+
+        if care_plan.user_id != user_id:
+            return jsonify({"error": "Unauthorized access to this care plan."}), 403
+
+        return jsonify(serialize_care_plan(care_plan)), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+    finally:
+        db.close()
+
+
 @plant_care_bp.route("/<int:care_log_id>", methods=["PATCH"])
 @jwt_required()
 @require_user_id

--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -447,6 +447,64 @@ def update_care_log(user_id, care_log_id):
         db.close()
 
 
+@plant_care_bp.route("/care-plans/<int:care_plan_id>", methods=["PATCH"])
+@jwt_required()
+@require_user_id
+def update_care_plan(user_id, care_plan_id):
+    """Updates an existing Care Plan by ID."""
+    db = SessionLocal()
+    plant_care_service = PlantCareService(db)
+
+    try:
+        # Fetch the care plan
+        care_plan = plant_care_service.get_care_plan_by_id(care_plan_id)
+
+        if not care_plan:
+            return jsonify({"error": "Care Plan not found"}), 404
+
+        if care_plan.user_id != user_id:  # type: ignore
+            return (
+                jsonify({"error": "Unauthorized: care plan does not belong to you"}),
+                403,
+            )
+
+        data = request.get_json()
+        allowed_fields = {
+            "plant_id",
+            "care_type_id",
+            "note",
+            "start_date",
+            "frequency_days",
+            "active",
+        }
+
+        updates = {k: v for k, v in data.items() if k in allowed_fields}
+
+        if not updates:
+            return jsonify({"error": "No valid fields provided for update."}), 400
+
+        updated = plant_care_service.update_care_plan(care_plan_id, updates)
+
+        if not updated:
+            return jsonify({"error": "Care Plan could not be updated."}), 400
+
+        return (
+            jsonify(
+                {
+                    "message": "Care Plan updated successfully!",
+                    "care_plan": serialize_care_plan(updated),
+                }
+            ),
+            200,
+        )
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+    finally:
+        db.close()
+
+
 @plant_care_bp.route("/<int:care_log_id>", methods=["DELETE"])
 @jwt_required()
 @require_user_id

--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -284,6 +284,26 @@ def get_care_log(user_id, care_log_id):
         db.close()
 
 
+@plant_care_bp.route("/care-plans/upcoming", methods=["GET"])
+@jwt_required()
+@require_user_id
+def get_upcoming_care_plans(user_id):
+    """Returns a list of upcoming plant care tasks."""
+    db = SessionLocal()
+    plant_care_service = PlantCareService(db)
+
+    try:
+        upcoming_logs = plant_care_service.get_upcoming_care_logs(user_id)
+        if not upcoming_logs:
+            return jsonify({"error": "Unable to find any upcoming care plans."}), 404
+
+        return jsonify(upcoming_logs), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+    finally:
+        db.close()
 @plant_care_bp.route("/<int:care_log_id>", methods=["PATCH"])
 @jwt_required()
 @require_user_id

--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -195,6 +195,7 @@ def create_care_plan(user_id):
         # Prepare data
         care_plan_data = {
             "plant_id": plant_id,
+            "user_id": user_id,
             "care_type_id": care_type_id,
             "note": note,
             "start_date": start_date,
@@ -211,6 +212,7 @@ def create_care_plan(user_id):
                     "message": "Care Plan created successfully!",
                     "care_plan": {
                         "id": new_care_plan.id,
+                        "user_id": new_care_plan.user_id,
                         "plant_id": new_care_plan.plant_id,
                         "care_type_id": new_care_plan.care_type_id,
                         "note": new_care_plan.note,

--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -4,9 +4,23 @@ from app.decorators.auth import require_user_id
 from app.models.database import SessionLocal
 from app.services.plant_service import PlantService
 from app.services.plant_care_service import PlantCareService
+from app.models.care_plan import CarePlan
 from datetime import datetime
 
 plant_care_bp = Blueprint("plant_care", __name__)
+
+
+def serialize_care_plan(plan: CarePlan) -> dict:
+    """Return a JSON dict from a care plan object"""
+    return {
+        "id": plan.id,
+        "plant_id": plan.plant_id,
+        "care_type_id": plan.care_type_id,
+        "note": plan.note,
+        "start_date": plan.start_date.isoformat(),
+        "frequency_days": plan.frequency_days,
+        "active": plan.active,
+    }
 
 
 @plant_care_bp.route("/plant/<int:plant_id>", methods=["GET"])

--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -5,7 +5,7 @@ from app.models.database import SessionLocal
 from app.services.plant_service import PlantService
 from app.services.plant_care_service import PlantCareService
 from app.models.care_plan import CarePlan
-from datetime import datetime
+from datetime import date, datetime
 
 plant_care_bp = Blueprint("plant_care", __name__)
 

--- a/backend/app/api/plant_care.py
+++ b/backend/app/api/plant_care.py
@@ -304,6 +304,28 @@ def get_upcoming_care_plans(user_id):
 
     finally:
         db.close()
+
+
+@plant_care_bp.route("/care-plans", methods=["GET"])
+@jwt_required()
+@require_user_id
+def get_user_care_plans(user_id):
+    """Returns a list of all a user's care plans."""
+    db = SessionLocal()
+    plant_care_service = PlantCareService(db)
+
+    try:
+        care_plans = plant_care_service.get_all_care_plans_for_user(user_id)
+        if not care_plans:
+            return jsonify({"error": "Unable to find any care plans."}), 404
+
+        return jsonify([serialize_care_plan(plan) for plan in care_plans]), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+    finally:
+        db.close()
 @plant_care_bp.route("/<int:care_log_id>", methods=["PATCH"])
 @jwt_required()
 @require_user_id


### PR DESCRIPTION
This PR adds:
- `POST /care-plans` – Create a new Care Plan  
- `GET /care-plans` – Get all Care Plans for the current user  
- `GET /care-plans/active` – Get only active Care Plans for the user  
- `GET /care-plans/upcoming` – Get upcoming care tasks based on Care Plans  
- `GET /care-plans/<care_plan_id>` – Get a specific Care Plan by ID  
- `PATCH /care-plans/<care_plan_id>` – Update an existing Care Plan  
- `DELETE /care-plans/<care_plan_id>` – Delete a Care Plan  
- `POST /care-plans/<care_plan_id>/log` – Create a PlantCare log from a Care Plan with optional note  